### PR TITLE
add license file and remote useless dependency

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Development Seed
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,14 @@ authors = [
   {name = "Anthony Lukach", email = "anthony@developmentseed.org"},
 ]
 dependencies = [
+  "fastapi-slim>=0.111.0",
   "pydantic-settings>=2.2.1",
   "pyjwt>=2.9.0",
   "cryptography>=43.0.0",
-  "fastapi-authorization-gateway>=0.0.3",
 ]
 description = "Authentication & authorization helpers for eoAPI"
 dynamic = ["version"]
-license = {text = "MIT"}
+license = {file = "LICENSE"}
 name = "eoapi.auth_utils"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -32,10 +32,3 @@ testing = [
   "pytest>=6.0",
   "coverage",
 ]
-
-[tool.setuptools]
-include-package-data = true
-py-modules = ["eoapi.auth_utils"]
-
-[tool.setuptools.packages.find]
-where = ["src"]


### PR DESCRIPTION
closes #4 

This PR does:
- add MIT license file (and update pyproject.toml to read from it)
- remove `fastapi-authorization-gateway` dependency and add `fastapi-slim` 
- remove useless setup tools config