### PR TITLE
Require fastapi rather than fastapi-slim

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 dependencies = [
   "cryptography>=43.0.0",
-  "fastapi-slim>=0.111.0",
+  "fastapi>=0.112.0",
   "pydantic-settings>=2.2.1",
   "pyjwt>=2.9.0",
 ]


### PR DESCRIPTION
FastAPI is now slim by default.
https://github.com/fastapi/fastapi/discussions/11525#discussioncomment-10219861
